### PR TITLE
[fix] Closing safety checks

### DIFF
--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -20,6 +20,18 @@ export class HttpHandler {
         //
     }
 
+    ready(res: HttpResponse) {
+        this.attachMiddleware(res, [
+            this.corsMiddleware,
+        ]).then(res => {
+            if (this.server.closing) {
+                this.serverErrorResponse(res, 'The server is closing. Choose another server. :)');
+            } else {
+                this.send(res, 'OK');
+            }
+        });
+    }
+
     healthCheck(res: HttpResponse) {
         this.attachMiddleware(res, [
             this.corsMiddleware,

--- a/src/server.ts
+++ b/src/server.ts
@@ -329,6 +329,7 @@ export class Server {
     protected configureHttp(server: TemplatedApp): Promise<TemplatedApp> {
         return new Promise(resolve => {
             server.get(this.url('/'), (res, req) => this.httpHandler.healthCheck(res));
+            server.get(this.url('/ready'), (res, req) => this.httpHandler.ready(res));
             server.get(this.url('/usage'), (res, req) => this.httpHandler.usage(res));
 
             if (this.options.metrics.enabled) {

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -78,7 +78,8 @@ export class WsHandler {
                 },
             });
 
-            return ws.end();
+            // See: https://www.iana.org/assignments/websocket/websocket.xhtml
+            return ws.end(1012);
         }
 
         ws.id = this.generateSocketId();
@@ -95,7 +96,8 @@ export class WsHandler {
                     },
                 });
 
-                return ws.end();
+                // See: https://www.iana.org/assignments/websocket/websocket.xhtml
+                return ws.end(1002);
             }
 
             ws.app = validApp.forWebSocket();
@@ -110,7 +112,8 @@ export class WsHandler {
                         },
                     });
 
-                    return ws.end();
+                    // See: https://www.iana.org/assignments/websocket/websocket.xhtml
+                    return ws.end(1002);
                 }
 
                 this.checkAppConnectionLimit(ws).then(canConnect => {
@@ -123,7 +126,8 @@ export class WsHandler {
                             },
                         });
 
-                        ws.end();
+                        // See: https://www.iana.org/assignments/websocket/websocket.xhtml
+                        ws.end(1013);
                     } else {
                         this.server.adapter.getNamespace(ws.app.id).addSocket(ws);
 
@@ -227,7 +231,8 @@ export class WsHandler {
                             },
                         });
 
-                        ws.end(1013);
+                        // See: https://www.iana.org/assignments/websocket/websocket.xhtml
+                        ws.end(1012);
                     } catch (e) {
                         //
                     }
@@ -492,6 +497,7 @@ export class WsHandler {
         if (!ws.subscribedChannels) {
             return Promise.resolve();
         }
+
         return async.each(ws.subscribedChannels, (channel, callback) => {
             this.unsubscribeFromChannel(ws, channel).then(() => callback());
         });
@@ -576,7 +582,7 @@ export class WsHandler {
                         code: 4301,
                         message: 'The rate limit for sending client events exceeded the quota.',
                     },
-                })
+                });
             });
         });
     }
@@ -658,6 +664,7 @@ export class WsHandler {
         this.clearTimeout(ws);
 
         ws.timeout = setTimeout(() => {
+            // See: https://www.iana.org/assignments/websocket/websocket.xhtml
             ws.end(1006);
         }, 120_000);
     }

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -269,12 +269,38 @@ export class WsHandler {
             event: 'pusher:pong',
             data: {},
         });
+
+        if (this.server.closing) {
+            ws.sendJson({
+                event: 'pusher:error',
+                data: {
+                    code: 4200,
+                    message: 'Server closed. Please reconnect shortly.',
+                },
+            });
+
+            // See: https://www.iana.org/assignments/websocket/websocket.xhtml
+            return ws.end(1012);
+        }
     }
 
     /**
      * Instruct the server to subscribe the connection to the channel.
      */
     subscribeToChannel(ws: WebSocket, message: any): any {
+        if (this.server.closing) {
+            ws.sendJson({
+                event: 'pusher:error',
+                data: {
+                    code: 4200,
+                    message: 'Server closed. Please reconnect shortly.',
+                },
+            });
+
+            // See: https://www.iana.org/assignments/websocket/websocket.xhtml
+            return ws.end(1012);
+        }
+
         let channel = message.data.channel;
         let channelManager = this.getChannelManagerFor(channel);
 


### PR DESCRIPTION
Closes #169 

This might break your app if you are seeking WebSocket statuses.

- Added a `/ready` endpoint to check if the server is pending closing (in Kubernetes you don't need that; use [Network Watcher](https://github.com/soketi/network-watcher) instead)
- When closing sockets, the command will send a [WebSocket Code](https://www.iana.org/assignments/websocket/websocket.xhtml) to mark the reason. In pusher this is irrelevant, but most are related to pending closing instances
- If the server is pending closing, the server will not allow existing sockets to subscribe to new channels, and will instead throw the `4200` code in Pusher (meaning reconnect immediately after) and close the socket