### PR TITLE
Switch to distroless container image and nonroot user

### DIFF
--- a/.github/workflows/docker-latest-distroless-tag.yml
+++ b/.github/workflows/docker-latest-distroless-tag.yml
@@ -30,7 +30,7 @@ jobs:
         ports:
           - 5000:5000
 
-    name: Tag & Test Latest (node:${{ matrix.node }})
+    name: Tag & Test Latest Distroless (node:${{ matrix.node }})
 
     steps:
       - uses: actions/checkout@v2
@@ -47,13 +47,14 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: localhost:5000/soketi/soketi:latest-${{ matrix.node }}-alpine
+          tags: localhost:5000/soketi/soketi:latest-${{ matrix.node }}-distroless
+          file: Dockerfile.distroless
           build-args: |
             VERSION=${{ matrix.node }}
 
       - name: Test
         run: |
-          docker run -d -p 6001:6001 -e DEBUG=1 localhost:5000/soketi/soketi:latest-${{ matrix.node }}-alpine
+          docker run -d -p 6001:6001 -e DEBUG=1 localhost:5000/soketi/soketi:latest-${{ matrix.node }}-distroless
           sleep 5
           curl --silent -XGET --fail http://127.0.0.1:6001
 
@@ -69,6 +70,7 @@ jobs:
         with:
           push: true
           context: .
-          tags: quay.io/soketi/soketi:latest-${{ matrix.node }}-alpine
+          tags: quay.io/soketi/soketi:latest-${{ matrix.node }}-distroless
+          file: Dockerfile.distroless
           build-args: |
             VERSION=${{ matrix.node }}

--- a/.github/workflows/docker-latest-tag.yml
+++ b/.github/workflows/docker-latest-tag.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - 14-alpine
-          - 16-alpine
+          - '14'
+          - '16'
 
     services:
       registry:
@@ -43,17 +43,32 @@ jobs:
         with:
           driver-opts: network=host
 
-      - name: Build testing image
+      - name: Build testing alpine image
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: localhost:5000/soketi/soketi:latest-${{ matrix.node }}
+          tags: localhost:5000/soketi/soketi:latest-${{ matrix.node }}-alpine
           build-args: |
             VERSION=${{ matrix.node }}
 
-      - name: Test
+      - name: Build testing distroless image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: localhost:5000/soketi/soketi:latest-${{ matrix.node }}-distroless
+          file: Dockerfile.distroless
+          build-args: |
+            VERSION=${{ matrix.node }}
+
+      - name: Test alpine
         run: |
-          docker run -d -p 6001:6001 -e DEBUG=1 localhost:5000/soketi/soketi:latest-${{ matrix.node }}
+          docker run -d -p 6001:6001 -e DEBUG=1 localhost:5000/soketi/soketi:latest-${{ matrix.node }}-alpine
+          sleep 5
+          curl --silent -XGET --fail http://127.0.0.1:6001
+
+      - name: Test distroless
+        run: |
+          docker run -d -p 6001:6001 -e DEBUG=1 localhost:5000/soketi/soketi:latest-${{ matrix.node }}-distroless
           sleep 5
           curl --silent -XGET --fail http://127.0.0.1:6001
 
@@ -64,11 +79,21 @@ jobs:
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
-      - name: Build and Push
+      - name: Build and Push Alpine
         uses: docker/build-push-action@v2
         with:
           push: true
           context: .
-          tags: quay.io/soketi/soketi:latest-${{ matrix.node }}
+          tags: quay.io/soketi/soketi:latest-${{ matrix.node }}-alpine
+          build-args: |
+            VERSION=${{ matrix.node }}
+
+      - name: Build and Push Distroless
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          tags: quay.io/soketi/soketi:latest-${{ matrix.node }}-distroless
+          file: Dockerfile.distroless
           build-args: |
             VERSION=${{ matrix.node }}

--- a/.github/workflows/docker-release-distroless-tag.yml
+++ b/.github/workflows/docker-release-distroless-tag.yml
@@ -17,7 +17,7 @@ jobs:
           - '14'
           - '16'
 
-    name: Tag Release (node:${{ matrix.node }})
+    name: Tag Distroless Release (node:${{ matrix.node }})
 
     steps:
       - uses: actions/checkout@v2
@@ -28,8 +28,8 @@ jobs:
         with:
           images: quay.io/soketi/soketi
           tags: |
-            type=semver,pattern={{version}}-${{ matrix.node }}-alpine
-            type=semver,pattern={{major}}.{{minor}}-${{ matrix.node }}-alpine
+            type=semver,pattern={{version}}-${{ matrix.node }}-distroless
+            type=semver,pattern={{major}}.{{minor}}-${{ matrix.node }}-distroless
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -55,5 +55,6 @@ jobs:
           context: .
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          file: Dockerfile.distroless
           build-args: |
             VERSION=${{ matrix.node }}

--- a/.github/workflows/docker-release-tag.yml
+++ b/.github/workflows/docker-release-tag.yml
@@ -14,22 +14,31 @@ jobs:
     strategy:
       matrix:
         node:
-          - 14-alpine
-          - 16-alpine
+          - '14'
+          - '16'
 
     name: Tag Release (node:${{ matrix.node }})
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Docker meta
-        id: docker_meta
+      - name: Docker Alpine meta
+        id: docker_alpine_meta
         uses: docker/metadata-action@v3.6.0
         with:
           images: quay.io/soketi/soketi
           tags: |
-            type=semver,pattern={{version}}-${{ matrix.node }}
-            type=semver,pattern={{major}}.{{minor}}-${{ matrix.node }}
+            type=semver,pattern={{version}}-${{ matrix.node }}-alpine
+            type=semver,pattern={{major}}.{{minor}}-${{ matrix.node }}-alpine
+      
+      - name: Docker Distroless meta
+        id: docker_distroless_meta
+        uses: docker/metadata-action@v3.6.0
+        with:
+          images: quay.io/soketi/soketi
+          tags: |
+            type=semver,pattern={{version}}-${{ matrix.node }}-distroless
+            type=semver,pattern={{major}}.{{minor}}-${{ matrix.node }}-distroless
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -48,12 +57,23 @@ jobs:
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
-      - name: Build and push (node:${{ matrix.node }})
+      - name: Build and push Alpine (node:${{ matrix.node }})
         uses: docker/build-push-action@v2
         with:
           push: true
           context: .
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.docker_alpine_meta.outputs.tags }}
+          labels: ${{ steps.docker_alpine_meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ matrix.node }}
+
+      - name: Build and push Distroless (node:${{ matrix.node }})
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.docker_distroless_meta.outputs.tags }}
+          labels: ${{ steps.docker_distroless_meta.outputs.labels }}
+          file: Dockerfile.distroless
           build-args: |
             VERSION=${{ matrix.node }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG VERSION=lts-alpine
+ARG VERSION=lts
 
-FROM node:$VERSION
+FROM node:$VERSION-alpine
 
 LABEL maintainer="Renoki Co. <alex@renoki.org>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=alpine-lts
+ARG VERSION=lts-alpine
 
 FROM node:$VERSION
 

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -18,8 +18,9 @@ RUN apk add --no-cache --update git python3 gcompat && \
     cd /tmp/build && \
     mv production-app/* /app/ && \
     chgrp -R 0 /app/ && \
-    chmod -R g+rx /app/
-
+    chmod -R g+rx /app/ && \
+    rm -rf /tmp/* /var/cache/* /usr/lib/python* && \
+    apk --purge del build-dependencies build-base gcc
 
 FROM gcr.io/distroless/nodejs:$VERSION
 

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,6 +1,6 @@
-ARG VERSION=lts-alpine
+ARG VERSION=16
 
-FROM node:$VERSION as base
+FROM node:$VERSION-alpine as base
 
 ENV PYTHONUNBUFFERED=1
 
@@ -21,7 +21,7 @@ RUN apk add --no-cache --update git python3 gcompat && \
     chmod -R g+rx /app/
 
 
-FROM gcr.io/distroless/nodejs:16
+FROM gcr.io/distroless/nodejs:$VERSION
 
 LABEL maintainer="Renoki Co. <alex@renoki.org>"
 

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,36 @@
+ARG VERSION=lts-alpine
+
+FROM node:$VERSION as base
+
+ENV PYTHONUNBUFFERED=1
+
+COPY . /tmp/build
+
+WORKDIR /tmp/build
+
+RUN apk add --no-cache --update git python3 gcompat && \
+    apk add --virtual build-dependencies build-base gcc wget && \
+    ln -sf python3 /usr/bin/python && \
+    python3 -m ensurepip && \
+    pip3 install --no-cache --upgrade pip setuptools && \
+    ash ./build-minimal-production && \
+    mkdir -p /app && \
+    cd /tmp/build && \
+    mv production-app/* /app/ && \
+    chgrp -R 0 /app/ && \
+    chmod -R g+rx /app/
+
+
+FROM gcr.io/distroless/nodejs:16
+
+LABEL maintainer="Renoki Co. <alex@renoki.org>"
+
+COPY --from=base /app /app
+
+WORKDIR /app
+
+USER 65534
+
+EXPOSE 6001
+
+CMD ["/app/bin/server.js", "start"]


### PR DESCRIPTION
This work hardens the existing dockerfile in two ways:

- by using a [distroless](https://github.com/GoogleContainerTools/distroless) image and,
- by running as a nonroot user. 

The advantage of using a distroless container is that, in the case of a remote code execution vulnerability the attacker cannot open a shell because there are not shells installed in the container. This makes an attack quite a bit harder to pull off, but can also make running something like `kubectl exec <your soketi pod> -- /bin/bash` to debug harder as, again, there is no shell in the container. I understand if that isn't a trade off the maintainers want to make, but I thought I'd show that its possible 😄

The advantage of a nonroot user is that in many container runtime environments the root user in a container is the same as the root user on the host (outside the container). This means that a container escape vulnerability is exploited the user becomes root on the host machine! This work changes the root user to UID 65534, but additionally allows the container to run as an arbitrary UID. This is helpful on platforms like Openshift that can randomize the user ID when running containers.

**Tests**
- `docker build -t soketi .` works locally
- `docker run -p 6001:6001 soketi` works and server starts correctly. Can `curl localhost:6001` and get a `OK` response.