### PR TITLE
[fix] Remove obsolete files (including Log4j) from context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git/**/*
+assets/**/*
+benchmark/**/*
+build/**/*
+coverage/**/*
+dist/**/*
+node_modules/**/*
+production-app/**/*
+tests/**/*
+.env
+npm-debug.log
+package-lock.json
+yarn.lock
+*.db


### PR DESCRIPTION
**This issue is not a security concern.**

For DynamoDB testing, soketi uses [DynamoDbLocal](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html). This server comes with additional files for it, like the recent [Log4j RCE vulnerability](https://www.whitesourcesoftware.com/resources/blog/log4j-vulnerability-cve-2021-45105/) which [are committed to the repo](https://github.com/soketi/soketi/tree/d1171f2400be3b764c2f376fdec0b9a409be72da/tests/fixtures/dynamodb/DynamoDBLocal_lib).

Docker seems to be adding them, but later on, it removes them in the process of building the Docker image. However, they still can be tracked in the Docker image layers' trace. To avoid false positives from automatic RCE checkers, they are removed from being added in the context entirely.

With the current fixes, they should be ignored, alongside other obsolete files like the benchmark folder.