### PR TITLE
[feature] Allow webhooks to define filters on the start and/or end of the channel name

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,8 +22,8 @@ export interface WebhookInterface {
     lambda_function?: string;
     event_types: string[];
     filter?: {
-        channel_starts_with?: string;
-        channel_ends_with?: string;
+        channel_name_starts_with?: string;
+        channel_name_ends_with?: string;
     };
     lambda: {
         async?: boolean;

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,8 @@ export interface WebhookInterface {
     url?: string;
     lambda_function?: string;
     event_types: string[];
+    channel_starts_with?: string;
+    channel_ends_with?: string;
     lambda: {
         async?: boolean;
         region?: string;

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,8 +21,10 @@ export interface WebhookInterface {
     url?: string;
     lambda_function?: string;
     event_types: string[];
-    channel_starts_with?: string;
-    channel_ends_with?: string;
+    filter?: {
+        channel_starts_with?: string;
+        channel_ends_with?: string;
+    };
     lambda: {
         async?: boolean;
         region?: string;

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -50,6 +50,14 @@ export class WebhookSender {
                         return;
                     }
 
+                    if (webhook.channel_starts_with && !payload.events[0].channel.startsWith(webhook.channel_starts_with)) {
+                        return;
+                    }
+
+                    if (webhook.channel_ends_with && !payload.events[0].channel.endsWith(webhook.channel_ends_with)) {
+                        return;
+                    }
+
                     if (this.server.options.debug) {
                         Log.webhookSenderTitle('🚀 Processing webhook from queue.');
                         Log.webhookSender({ appKey, payload, pusherSignature });

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -50,11 +50,11 @@ export class WebhookSender {
                         return;
                     }
 
-                    if (webhook.channel_starts_with && !payload.events[0].channel.startsWith(webhook.channel_starts_with)) {
+                    if (webhook.filter?.channel_starts_with && !payload.events[0].channel.startsWith(webhook.filter.channel_starts_with)) {
                         return;
                     }
 
-                    if (webhook.channel_ends_with && !payload.events[0].channel.endsWith(webhook.channel_ends_with)) {
+                    if (webhook.filter?.channel_ends_with && !payload.events[0].channel.endsWith(webhook.filter.channel_ends_with)) {
                         return;
                     }
 

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -50,11 +50,11 @@ export class WebhookSender {
                         return;
                     }
 
-                    if (webhook.filter?.channel_starts_with && !payload.events[0].channel.startsWith(webhook.filter.channel_starts_with)) {
+                    if (webhook.filter?.channel_name_starts_with && !payload.events[0].channel.startsWith(webhook.filter.channel_name_starts_with)) {
                         return;
                     }
 
-                    if (webhook.filter?.channel_ends_with && !payload.events[0].channel.endsWith(webhook.filter.channel_ends_with)) {
+                    if (webhook.filter?.channel_name_ends_with && !payload.events[0].channel.endsWith(webhook.filter.channel_name_ends_with)) {
                         return;
                     }
 

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -266,4 +266,80 @@ describe('webhooks test', () => {
             });
         });
     }, 60 * 1000);
+
+    Utils.shouldRun(Utils.appManagerIs('array') && Utils.adapterIs('local'))('webhooks filtered by channel name', done => {
+        const sharedWebhookConfig = {
+            event_types: ['channel_occupied'],
+            url: 'http://127.0.0.1:3001/webhook',
+        };
+
+        const webhooks = [
+            {
+                ...sharedWebhookConfig,
+                channel_starts_with: 'private-',
+            },
+            {
+                ...sharedWebhookConfig,
+                channel_starts_with: 'private-',
+                channel_ends_with: '-foo',
+            },
+            {
+                ...sharedWebhookConfig,
+                channel_ends_with: '-bar',
+            },
+        ];
+
+        // We expect the webhook to be called 1 time for these channels
+        const matchedChannels = [
+            `private-${Utils.randomChannelName()}`,
+            `private-${Utils.randomChannelName()}-foo`,
+            `${Utils.randomChannelName()}-bar`,
+        ];
+
+        // We don't expect any webhooks to be called for these channels
+        const unmatchedChannels = [
+            `public-${Utils.randomChannelName()}`,
+            `public-${Utils.randomChannelName()}-foo`,
+            `${Utils.randomChannelName()}-foo`,
+        ];
+
+        const expectedWebhookRequests = matchedChannels.length;
+
+        Utils.newServer({
+            'appManager.array.apps.0.enableClientMessages': true,
+            'appManager.array.apps.0.webhooks': webhooks,
+            'database.redis.keyPrefix': 'channel-webhooks',
+        }, (server: Server) => {
+            let receivedWebhookRequests = 0;
+
+            Utils.newWebhookServer((req, res) => {
+                let app = new App(server.options.appManager.array.apps[0]);
+                let rightSignature = createWebhookHmac(JSON.stringify(req.body), app.secret);
+
+                expect(req.headers['x-pusher-key']).toBe('app-key');
+                expect(req.headers['x-pusher-signature']).toBe(rightSignature);
+                expect(req.body.time_ms).toBeDefined();
+                expect(req.body.events).toBeDefined();
+                expect(req.body.events.length).toBe(1);
+
+                const webhookEvent = req.body.events[0];
+
+                if (matchedChannels.includes(webhookEvent.channel)) {
+                    receivedWebhookRequests += 1;
+                }
+
+                res.json({ ok: true });
+
+                if (receivedWebhookRequests >= expectedWebhookRequests) {
+                    done();
+                }
+            }, (activeHttpServer) => {
+                let client = Utils.newClientForPrivateChannel();
+
+                client.connection.bind('connected', () => {
+                    [...unmatchedChannels, ...matchedChannels].forEach(channelName => client.subscribe(channelName));
+                });
+            });
+        });
+    }, 60 * 1000);
 });

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -276,16 +276,22 @@ describe('webhooks test', () => {
         const webhooks = [
             {
                 ...sharedWebhookConfig,
-                channel_starts_with: 'private-',
+                filter: {
+                    channel_starts_with: 'private-',
+                },
             },
             {
                 ...sharedWebhookConfig,
-                channel_starts_with: 'private-',
-                channel_ends_with: '-foo',
+                filter: {
+                    channel_starts_with: 'private-',
+                    channel_ends_with: '-foo',
+                },
             },
             {
                 ...sharedWebhookConfig,
-                channel_ends_with: '-bar',
+                filter: {
+                    channel_ends_with: '-bar',
+                },
             },
         ];
 

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -277,20 +277,20 @@ describe('webhooks test', () => {
             {
                 ...sharedWebhookConfig,
                 filter: {
-                    channel_starts_with: 'private-',
+                    channel_name_starts_with: 'private-',
                 },
             },
             {
                 ...sharedWebhookConfig,
                 filter: {
-                    channel_starts_with: 'private-',
-                    channel_ends_with: '-foo',
+                    channel_name_starts_with: 'private-',
+                    channel_name_ends_with: '-foo',
                 },
             },
             {
                 ...sharedWebhookConfig,
                 filter: {
-                    channel_ends_with: '-bar',
+                    channel_name_ends_with: '-bar',
                 },
             },
         ];


### PR DESCRIPTION
In our app we have a lot of traffic on channels. For our purposes only a few channels need to actually fire a webhook so our app can track it's state. Adding a filter on the channel name for the webhook allow us to cut down on the amount of "useless" webhook traffic.

I propose we add a `channel_starts_with` and `channel_ends_with` option to a webhook that has to match before a webhook is fired (if both are defined both need to match). I opted to keep this as simple as possible and not try to deal with regex or multiple matchers per webhook but if wanted we can always discuss on how to do that the best.

Let me know what you think!