### PR TITLE
Ability to configure custom headers for webhooks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,9 @@ export interface AppInterface {
 
 export interface WebhookInterface {
     url?: string;
+    headers?: {
+        [key: string]: string
+    };
     lambda_function?: string;
     event_types: string[];
     filter?: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ export interface AppInterface {
 export interface WebhookInterface {
     url?: string;
     headers?: {
-        [key: string]: string
+        [key: string]: string;
     };
     lambda_function?: string;
     event_types: string[];

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -67,6 +67,8 @@ export class WebhookSender {
                         'Accept': 'application/json',
                         'Content-Type': 'application/json',
                         'User-Agent': `SoketiWebhooksAxiosClient/1.0 (Process: ${this.server.options.instance.process_id})`,
+                        // We specifically merge in the custom headers here so the headers below cannot be overwritten
+                        ...webhook.headers ?? {},
                         'X-Pusher-Key': appKey,
                         'X-Pusher-Signature': pusherSignature,
                     };

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -348,4 +348,47 @@ describe('webhooks test', () => {
             });
         });
     }, 60 * 1000);
+
+    Utils.shouldRun(Utils.appManagerIs('array') && Utils.adapterIs('local'))('webhooks can have custom headers', done => {
+        const webhooks = [{
+            event_types: ['channel_occupied'],
+            url: 'http://127.0.0.1:3001/webhook',
+            headers: {
+                'X-Custom-Header': 'custom-value',
+                // These headers below should not be sent with `custom-value`
+                'X-Pusher-Key': 'custom-value',
+                'X-Pusher-Signature': 'custom-value',
+            },
+        }];
+
+        const channelName = `private-${Utils.randomChannelName()}`;
+
+        Utils.newServer({
+            'appManager.array.apps.0.enableClientMessages': true,
+            'appManager.array.apps.0.webhooks': webhooks,
+            'database.redis.keyPrefix': 'channel-webhooks',
+        }, (server: Server) => {
+            Utils.newWebhookServer((req, res) => {
+                let app = new App(server.options.appManager.array.apps[0]);
+                let rightSignature = createWebhookHmac(JSON.stringify(req.body), app.secret);
+
+                expect(req.headers['x-pusher-key']).toBe('app-key');
+                expect(req.headers['x-pusher-signature']).toBe(rightSignature);
+                expect(req.headers['x-custom-header']).toBe('custom-value');
+                expect(req.body.time_ms).toBeDefined();
+                expect(req.body.events).toBeDefined();
+                expect(req.body.events.length).toBe(1);
+
+                res.json({ ok: true });
+
+                done();
+            }, (activeHttpServer) => {
+                let client = Utils.newClientForPrivateChannel();
+
+                client.connection.bind('connected', () => {
+                    client.subscribe(channelName);
+                });
+            });
+        });
+    }, 60 * 1000);
 });

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -82,7 +82,6 @@ describe('webhooks test', () => {
         let channelName = `private-${Utils.randomChannelName()}`;
 
         Utils.newServer({
-            'appManager.array.apps.0.enableClientMessages': true,
             'appManager.array.apps.0.webhooks': webhooks,
             'database.redis.keyPrefix': 'channel-webhooks',
         }, (server: Server) => {
@@ -131,7 +130,6 @@ describe('webhooks test', () => {
         let channelName = `presence-${Utils.randomChannelName()}`;
 
         Utils.newServer({
-            'appManager.array.apps.0.enableClientMessages': true,
             'appManager.array.apps.0.webhooks': webhooks,
             'database.redis.keyPrefix': 'presence-webhooks',
         }, (server: Server) => {
@@ -312,7 +310,6 @@ describe('webhooks test', () => {
         const expectedWebhookRequests = matchedChannels.length;
 
         Utils.newServer({
-            'appManager.array.apps.0.enableClientMessages': true,
             'appManager.array.apps.0.webhooks': webhooks,
             'database.redis.keyPrefix': 'channel-webhooks',
         }, (server: Server) => {
@@ -364,7 +361,6 @@ describe('webhooks test', () => {
         const channelName = `private-${Utils.randomChannelName()}`;
 
         Utils.newServer({
-            'appManager.array.apps.0.enableClientMessages': true,
             'appManager.array.apps.0.webhooks': webhooks,
             'database.redis.keyPrefix': 'channel-webhooks',
         }, (server: Server) => {


### PR DESCRIPTION
Title is pretty descriptive here I think :)

Also removed the `enableClientMessages` in the webhook tests where client events are not used to prevent confusion.