### PR TITLE
Fix default Redis queue job options

### DIFF
--- a/src/queues/queue.ts
+++ b/src/queues/queue.ts
@@ -1,4 +1,4 @@
-import { Log } from './../log';
+import { Log } from '../log';
 import { QueueInterface } from './queue-interface';
 import { RedisQueueDriver } from './redis-queue-driver';
 import { SyncQueueDriver } from './sync-queue-driver';
@@ -11,7 +11,7 @@ export class Queue implements QueueInterface {
     public driver: QueueInterface;
 
     /**
-     * Initialize the queue exporter.
+     * Initialize the queue.
      */
     constructor(protected server: Server) {
         if (server.options.queue.driver === 'sync') {
@@ -19,7 +19,7 @@ export class Queue implements QueueInterface {
         } else if (server.options.queue.driver === 'redis') {
             this.driver = new RedisQueueDriver(server);
         } else {
-            Log.error('No queue driver specified.');
+            Log.error('No valid queue driver specified.');
         }
     }
 

--- a/src/queues/redis-queue-driver.ts
+++ b/src/queues/redis-queue-driver.ts
@@ -35,7 +35,6 @@ export class RedisQueueDriver implements QueueInterface {
                 return resolve();
             }
 
-            // TODO: Retry policy? https://docs.bullmq.io/guide/retrying-failing-jobs
             queueWithWorker.queue.add('webhook', data).then(() => resolve());
         });
     }

--- a/src/queues/redis-queue-driver.ts
+++ b/src/queues/redis-queue-driver.ts
@@ -1,7 +1,7 @@
 import async from 'async';
-import {Queue, Worker, QueueScheduler} from 'bullmq'
-import {QueueInterface} from './queue-interface';
-import {Server} from '../server';
+import { Queue, Worker, QueueScheduler } from 'bullmq'
+import { QueueInterface } from './queue-interface';
+import { Server } from '../server';
 
 const Redis = require('ioredis');
 
@@ -56,7 +56,7 @@ export class RedisQueueDriver implements QueueInterface {
                 // We remove a trailing `:` from the prefix because BullMQ adds that already
                 const prefix = this.server.options.database.redis.keyPrefix.replace(/:$/, '');
 
-                const sharedOptions = {prefix, connection};
+                const sharedOptions = { prefix, connection };
 
                 this.queueWithWorker.set(queueName, {
                     queue: new Queue(queueName, {
@@ -90,7 +90,7 @@ export class RedisQueueDriver implements QueueInterface {
      * Clear the queues for a graceful shutdown.
      */
     clear(): Promise<void> {
-        return async.each([...this.queueWithWorker], ([queueName, {queue, worker, scheduler}]: [string, QueueWithWorker], callback) => {
+        return async.each([...this.queueWithWorker], ([queueName, { queue, worker, scheduler }]: [string, QueueWithWorker], callback) => {
             scheduler.close().then(() => {
                 worker.close().then(() => callback());
             });

--- a/src/queues/redis-queue-driver.ts
+++ b/src/queues/redis-queue-driver.ts
@@ -55,7 +55,15 @@ export class RedisQueueDriver implements QueueInterface {
                 this.queueWithWorker.set(queueName, {
                     queue: new Queue(queueName, {
                         connection,
-                        defaultJobOptions: { attempts: 6, delay: 1000 },
+                        defaultJobOptions: {
+                            attempts: 6,
+                            backoff: {
+                                type: 'exponential',
+                                delay: 1000,
+                            },
+                            removeOnComplete: true,
+                            removeOnFail: true,
+                        },
                     }),
                     // TODO: Sandbox the worker? https://docs.bullmq.io/guide/workers/sandboxed-processors
                     worker: new Worker(queueName, callback as any, {

--- a/src/queues/redis-queue-driver.ts
+++ b/src/queues/redis-queue-driver.ts
@@ -17,7 +17,7 @@ export class RedisQueueDriver implements QueueInterface {
     protected queueWithWorker: Map<string, QueueWithWorker> = new Map();
 
     /**
-     * Initialize the Prometheus exporter.
+     * Initialize the Redis Queue Driver.
      */
     constructor(protected server: Server) {
         //

--- a/src/queues/redis-queue-driver.ts
+++ b/src/queues/redis-queue-driver.ts
@@ -45,8 +45,7 @@ export class RedisQueueDriver implements QueueInterface {
     processQueue(queueName: string, callback: CallableFunction): Promise<void> {
         return new Promise(resolve => {
             if (!this.queueWithWorker.has(queueName)) {
-
-                let connection = new Redis({
+                const connection = new Redis({
                     maxRetriesPerRequest: null,
                     enableReadyCheck: false,
                     ...this.server.options.database.redis,
@@ -74,7 +73,7 @@ export class RedisQueueDriver implements QueueInterface {
                     //       A single scheduler per queue is needed: https://docs.bullmq.io/guide/queuescheduler
                     scheduler: new QueueScheduler(queueName, {
                         connection,
-                    })
+                    }),
                 });
             }
 

--- a/src/queues/sync-queue-driver.ts
+++ b/src/queues/sync-queue-driver.ts
@@ -10,7 +10,7 @@ export class SyncQueueDriver implements QueueInterface {
     protected queues: Map<string, CallableFunction> = new Map();
 
     /**
-     * Initialize the Prometheus exporter.
+     * Initialize the Sync Queue Driver.
      */
     constructor(protected server: Server) {
         //


### PR DESCRIPTION
So as it turns out the default job options for the Redis queue were causing jobs to never be processed.

> Delayed jobs will only be processed if there is at least one QueueScheduler instance configured in the Queue.
> https://docs.bullmq.io/guide/jobs/delayed

These are our default job options `defaultJobOptions: { attempts: 6, delay: 1000 },`.

So because of the delay and not having a `QueueScheduler` they are never ever processed :)

I've set some options to have an exponential backoff for failed job which I think was the original idea behind the `delay` option in being here in the first place and also added the needed `QueueScheduler` so jobs are properly scheduled once delayed.

The `removeOnComplete` and `removeOnFail` options remove the job information from Redis once they are completed or fully failed (after retries) to prevent bloating up Redis.

This also fixes the handling of the Redis key prefix, BullMQ does not like it when it's set on the connection so we set the prefix to be handled by BullMQ itself so it's consistent.

Fixes #227.