### PR TITLE
[feature] `/batch_events` call

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "typescript": "^4.5.3"
   },
   "scripts": {
-    "build": "./node_modules/.bin/tsc",
-    "build:watch": "./node_modules/.bin/tsc -W",
+    "build": "node node_modules/typescript/bin/tsc",
+    "build:watch": "npm run build -- -W",
     "lint": "eslint --ext .js,.ts ./src",
     "prepublish": "npm run build",
     "test": "jest --detectOpenHandles --forceExit --silent",

--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -1,5 +1,5 @@
 import { Namespace } from '../namespace';
-import { PresenceMember } from '../presence-member';
+import { PresenceMember } from '../channels/presence-channel-manager';
 import { WebSocket } from 'uWebSockets.js';
 
 const Discover = require('node-discover');

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -3,7 +3,7 @@ import { ClusterAdapter } from './cluster-adapter';
 import { LocalAdapter } from './local-adapter';
 import { Log } from '../log';
 import { Namespace } from '../namespace';
-import { PresenceMember } from '../presence-member';
+import { PresenceMember } from '../channels/presence-channel-manager';
 import { RedisAdapter } from './redis-adapter';
 import { Server } from '../server';
 import { WebSocket } from 'uWebSockets.js';

--- a/src/adapters/horizontal-adapter.ts
+++ b/src/adapters/horizontal-adapter.ts
@@ -1,6 +1,6 @@
 import { LocalAdapter } from './local-adapter';
 import { Log } from '../log';
-import { PresenceMember } from '../presence-member';
+import { PresenceMember } from '../channels/presence-channel-manager';
 import { v4 as uuidv4 } from 'uuid';
 import { WebSocket } from 'uWebSockets.js';
 

--- a/src/adapters/local-adapter.ts
+++ b/src/adapters/local-adapter.ts
@@ -1,6 +1,6 @@
 import { AdapterInterface } from './adapter-interface';
 import { Namespace } from '../namespace';
-import { PresenceMember } from '../presence-member';
+import { PresenceMember } from '../channels/presence-channel-manager';
 import { Server } from '../server';
 import { WebSocket } from 'uWebSockets.js';
 

--- a/src/channels/presence-channel-manager.ts
+++ b/src/channels/presence-channel-manager.ts
@@ -1,15 +1,21 @@
 import { JoinResponse, LeaveResponse } from './public-channel-manager';
 import { Log } from '../log';
-import { PresenceMember } from '../presence-member';
 import { PrivateChannelManager } from './private-channel-manager';
+import { PusherMessage } from '../message';
 import { Utils } from '../utils';
 import { WebSocket } from 'uWebSockets.js';
+
+export interface PresenceMember {
+    user_id: number|string;
+    user_info: any;
+    socket_id?: string;
+}
 
 export class PresenceChannelManager extends PrivateChannelManager {
     /**
      * Join the connection to the channel.
      */
-    join(ws: WebSocket, channel: string, message?: any): Promise<JoinResponse> {
+    join(ws: WebSocket, channel: string, message?: PusherMessage): Promise<JoinResponse> {
         return this.server.adapter.getChannelMembersCount(ws.app.id, channel).then(membersCount => {
             if (membersCount + 1 > this.server.options.presence.maxMembersPerChannel) {
                 return {
@@ -77,7 +83,7 @@ export class PresenceChannelManager extends PrivateChannelManager {
     /**
      * Get the data to sign for the token for specific channel.
      */
-    protected getDataToSignForSignature(socketId: string, message: any): string {
+    protected getDataToSignForSignature(socketId: string, message: PusherMessage): string {
         return `${socketId}:${message.data.channel}:${message.data.channel_data}`;
     }
 }

--- a/src/channels/private-channel-manager.ts
+++ b/src/channels/private-channel-manager.ts
@@ -1,5 +1,6 @@
 import { App } from '../app';
 import { JoinResponse, PublicChannelManager } from './public-channel-manager';
+import { PusherMessage } from '../message';
 import { WebSocket } from 'uWebSockets.js';
 
 const Pusher = require('pusher');
@@ -8,7 +9,7 @@ export class PrivateChannelManager extends PublicChannelManager {
     /**
      * Join the connection to the channel.
      */
-    join(ws: WebSocket, channel: string, message?: any): Promise<JoinResponse> {
+    join(ws: WebSocket, channel: string, message?: PusherMessage): Promise<JoinResponse> {
         let passedSignature = message?.data?.auth;
 
         return this.signatureIsValid(ws.app, ws.id, message, passedSignature).then(isValid => {
@@ -30,7 +31,7 @@ export class PrivateChannelManager extends PublicChannelManager {
     /**
      * Check is an incoming connection can subscribe.
      */
-    protected signatureIsValid(app: App, socketId: string, message: any, signatureToCheck: string): Promise<boolean> {
+    protected signatureIsValid(app: App, socketId: string, message: PusherMessage, signatureToCheck: string): Promise<boolean> {
         return this.getExpectedSignature(app, socketId, message).then(expectedSignature => {
             return signatureToCheck === expectedSignature;
         });
@@ -39,7 +40,7 @@ export class PrivateChannelManager extends PublicChannelManager {
     /**
      * Get the signed token from the given message, by the Socket.
      */
-    protected getExpectedSignature(app: App, socketId: string, message: any): Promise<string> {
+    protected getExpectedSignature(app: App, socketId: string, message: PusherMessage): Promise<string> {
         return new Promise(resolve => {
             let token = new Pusher.Token(app.key, app.secret);
 
@@ -52,7 +53,7 @@ export class PrivateChannelManager extends PublicChannelManager {
     /**
      * Get the data to sign for the token for specific channel.
      */
-    protected getDataToSignForSignature(socketId: string, message: any): string {
+    protected getDataToSignForSignature(socketId: string, message: PusherMessage): string {
         return `${socketId}:${message.data.channel}`;
     }
 }

--- a/src/channels/public-channel-manager.ts
+++ b/src/channels/public-channel-manager.ts
@@ -1,6 +1,7 @@
-import { PresenceMember } from '../presence-member';
+import { PresenceMember } from '../channels/presence-channel-manager';
 import { WebSocket } from 'uWebSockets.js';
 import { Server } from '../server';
+import { PusherMessage } from '../message';
 
 export interface JoinResponse {
     ws: WebSocket;
@@ -27,7 +28,7 @@ export class PublicChannelManager {
     /**
      * Join the connection to the channel.
      */
-    join(ws: WebSocket, channel: string, message?: any): Promise<JoinResponse> {
+    join(ws: WebSocket, channel: string, message?: PusherMessage): Promise<JoinResponse> {
         return this.server.adapter.getNamespace(ws.app.id).addToChannel(ws, channel).then(connections => {
             return {
                 ws,

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -66,6 +66,7 @@ export class Cli {
         DB_REDIS_SENTINELS: 'database.redis.sentinels',
         DB_REDIS_SENTINEL_PASSWORD: 'database.redis.sentinelPassword',
         DB_REDIS_INSTANCE_NAME: 'database.redis.name',
+        EVENT_MAX_BATCH_SIZE: 'eventLimits.maxBatchSize',
         EVENT_MAX_CHANNELS_AT_ONCE: 'eventLimits.maxChannelsAtOnce',
         EVENT_MAX_NAME_LENGTH: 'eventLimits.maxNameLength',
         EVENT_MAX_SIZE_IN_KB: 'eventLimits.maxPayloadInKb',

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -242,6 +242,11 @@ export class HttpHandler {
         ]).then(res => {
             let batch = res.body.batch as PusherApiMessage[];
 
+            // Make sure the batch size is not too big.
+            if (batch.length > this.server.options.eventLimits.maxBatchSize) {
+                return this.badResponse(res, `Cannot batch-send more than ${this.server.options.eventLimits.maxBatchSize} messages at once`);
+            }
+
             Promise.all(batch.map(message => this.checkMessageToBroadcast(message))).then(messages => {
                 messages.forEach(message => this.broadcastMessage(message, res.app.id));
                 this.sendJson(res, { ok: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ export * from './job';
 export * from './log';
 export * from './namespace';
 export * from './options';
-export * from './presence-member';
 export * from './server';
 export * from './utils';
 export * from './webhook-sender';

--- a/src/job.ts
+++ b/src/job.ts
@@ -4,7 +4,7 @@ export class Job {
     /**
      * Create a new job instance.
      */
-    constructor(public id: string = uuidv4(), public data: any = {}) {
+    constructor(public id: string = uuidv4(), public data: { [key: string]: any; } = {}) {
         //
     }
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,0 +1,20 @@
+export interface MessageData {
+    channel_data?: string;
+    channel?: string;
+    [key: string]: any;
+}
+
+export interface PusherMessage {
+    channel?: string;
+    name?: string;
+    event?: string;
+    data?: MessageData;
+}
+
+export interface SentPusherMessage {
+    channel?: string;
+    event?: string;
+    data?: MessageData|string;
+}
+
+export type uWebSocketMessage = ArrayBuffer|PusherMessage;

--- a/src/message.ts
+++ b/src/message.ts
@@ -11,6 +11,14 @@ export interface PusherMessage {
     data?: MessageData;
 }
 
+export interface PusherApiMessage {
+    name?: string;
+    data?: string|{ [key: string]: any };
+    channel?: string;
+    channels?: string[];
+    socket_id?: string;
+}
+
 export interface SentPusherMessage {
     channel?: string;
     event?: string;

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,4 +1,4 @@
-import { PresenceMember } from './presence-member';
+import { PresenceMember } from './channels/presence-channel-manager';
 import { WebSocket } from 'uWebSockets.js';
 
 export class Namespace {

--- a/src/options.ts
+++ b/src/options.ts
@@ -86,6 +86,7 @@ export interface Options {
         maxChannelsAtOnce: string|number;
         maxNameLength: string|number;
         maxPayloadInKb: string|number;
+        maxBatchSize: string|number;
     };
     httpApi: {
         requestLimitInMb: string|number;

--- a/src/presence-member.ts
+++ b/src/presence-member.ts
@@ -1,5 +1,0 @@
-export interface PresenceMember {
-    user_id: number|string;
-    user_info: any;
-    socket_id?: string;
-}

--- a/src/server.ts
+++ b/src/server.ts
@@ -558,6 +558,15 @@ export class Server {
                 return this.httpHandler.events(res);
             });
 
+            server.post(this.url('/apps/:appId/batch_events'), (res, req) => {
+                res.params = { appId: req.getParameter(0) };
+                res.query = queryString.parse(req.getQuery());
+                res.method = req.getMethod().toUpperCase();
+                res.url = req.getUrl();
+
+                return this.httpHandler.batchEvents(res);
+            });
+
             server.any(this.url('/*'), (res, req) => {
                 return this.httpHandler.notFound(res);
             });

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { Queue } from './queues/queue';
 import { QueueInterface } from './queues/queue-interface';
 import { RateLimiter } from './rate-limiters/rate-limiter';
 import { RateLimiterInterface } from './rate-limiters/rate-limiter-interface';
+import { uWebSocketMessage } from './message';
 import { v4 as uuidv4 } from 'uuid';
 import { WebhookSender } from './webhook-sender';
 import { WebSocket } from 'uWebSockets.js';
@@ -503,9 +504,9 @@ export class Server {
                 idleTimeout: 120, // According to protocol
                 maxBackpressure: 1024 * 1024,
                 maxPayloadLength: 100 * 1024 * 1024, // 100 MB
-                message: (ws: WebSocket, message: any, isBinary: boolean) => this.wsHandler.onMessage(ws, message, isBinary),
+                message: (ws: WebSocket, message: uWebSocketMessage, isBinary: boolean) => this.wsHandler.onMessage(ws, message, isBinary),
                 open: (ws: WebSocket) => this.wsHandler.onOpen(ws),
-                close: (ws: WebSocket, code: number, message: any) => this.wsHandler.onClose(ws, code, message),
+                close: (ws: WebSocket, code: number, message: uWebSocketMessage) => this.wsHandler.onClose(ws, code, message),
                 upgrade: (res: HttpResponse, req: HttpRequest, context) => this.wsHandler.handleUpgrade(res, req, context),
             });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,6 +131,7 @@ export class Server {
             maxChannelsAtOnce: 100,
             maxNameLength: 200,
             maxPayloadInKb: 100,
+            maxBatchSize: 10,
         },
         httpApi: {
             requestLimitInMb: 100,

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -5,9 +5,10 @@ import { HttpRequest, HttpResponse } from 'uWebSockets.js';
 import { Log } from './log';
 import { Namespace } from './namespace';
 import { PresenceChannelManager } from './channels';
-import { PresenceMember } from './presence-member';
+import { PresenceMember } from './channels/presence-channel-manager';
 import { PrivateChannelManager } from './channels';
 import { PublicChannelManager } from './channels';
+import { PusherMessage, uWebSocketMessage } from './message';
 import { Server } from './server';
 import { Utils } from './utils';
 import { WebSocket } from 'uWebSockets.js';
@@ -152,10 +153,10 @@ export class WsHandler {
     /**
      * Handle a received message from the client.
      */
-    onMessage(ws: WebSocket, message: any, isBinary: boolean): any {
+    onMessage(ws: WebSocket, message: uWebSocketMessage, isBinary: boolean): any {
         if (message instanceof ArrayBuffer) {
             try {
-                message = JSON.parse(ab2str(message));
+                message = JSON.parse(ab2str(message)) as PusherMessage;
             } catch (err) {
                 return;
             }
@@ -191,7 +192,7 @@ export class WsHandler {
     /**
      * Handle the event of the client closing the connection.
      */
-    onClose(ws: WebSocket, code: number, message: any): any {
+    onClose(ws: WebSocket, code: number, message: uWebSocketMessage): any {
         if (this.server.options.debug) {
             Log.websocketTitle('❌ Connection closed:');
             Log.websocket({ ws, code, message });
@@ -291,7 +292,7 @@ export class WsHandler {
     /**
      * Instruct the server to subscribe the connection to the channel.
      */
-    subscribeToChannel(ws: WebSocket, message: any): any {
+    subscribeToChannel(ws: WebSocket, message: PusherMessage): any {
         if (this.server.closing) {
             ws.sendJson({
                 event: 'pusher:error',
@@ -501,7 +502,7 @@ export class WsHandler {
     /**
      * Handle the events coming from the client.
      */
-    handleClientEvent(ws: WebSocket, message: any): any {
+    handleClientEvent(ws: WebSocket, message: PusherMessage): any {
         let { event, data, channel } = message;
 
         if (!ws.app.enableClientMessages) {

--- a/tests/http-api.test.ts
+++ b/tests/http-api.test.ts
@@ -325,10 +325,10 @@ describe('http api test', () => {
                 });
 
                 channel.bind('pusher:subscription_succeeded', () => {
-                    Utils.sendBatches(backend, [
-                        { name: 'greeting', channels: [channelName], data: { message: 'hello', weirdVariable: 'abc/d' } },
-                        { name: 'greeting', channels: [channelName], data: { message: 'hello', weirdVariable: 'abc/d' } },
-                        { name: 'greeting', channels: [channelName], data: { message: 'hello', weirdVariable: 'abc/d' } },
+                    Utils.sendBatch(backend, [
+                        { name: 'greeting', channel: channelName, data: { message: 'hello', weirdVariable: 'abc/d' } },
+                        { name: 'greeting', channel: channelName, data: { message: 'hello', weirdVariable: 'abc/d' } },
+                        { name: 'greeting', channel: channelName, data: { message: 'hello', weirdVariable: 'abc/d' } },
                     ]).catch(error => {
                         throw new Error(error);
                     });

--- a/tests/http-api.test.ts
+++ b/tests/http-api.test.ts
@@ -302,6 +302,41 @@ describe('http api test', () => {
         });
     });
 
+    test('sends batch events', done => {
+        Utils.newServer({}, (server: Server) => {
+            let client = Utils.newClient();
+            let backend = Utils.newBackend();
+            let channelName = Utils.randomChannelName();
+
+            client.connection.bind('connected', () => {
+                let channel = client.subscribe(channelName);
+                let receivedMessages = 0;
+
+                channel.bind('greeting', e => {
+                    expect(e.message).toBe('hello');
+                    expect(e.weirdVariable).toBe('abc/d');
+
+                    receivedMessages++;
+
+                    if (receivedMessages === 3) {
+                        client.disconnect();
+                        done();
+                    }
+                });
+
+                channel.bind('pusher:subscription_succeeded', () => {
+                    Utils.sendBatches(backend, [
+                        { name: 'greeting', channels: [channelName], data: { message: 'hello', weirdVariable: 'abc/d' } },
+                        { name: 'greeting', channels: [channelName], data: { message: 'hello', weirdVariable: 'abc/d' } },
+                        { name: 'greeting', channels: [channelName], data: { message: 'hello', weirdVariable: 'abc/d' } },
+                    ]).catch(error => {
+                        throw new Error(error);
+                    });
+                });
+            });
+        });
+    });
+
     test('passing an inexistent app id will return 404', done => {
         Utils.newServer({}, (server: Server) => {
             let backend = Utils.newBackend('inexistent-app-id');

--- a/tests/http-api.test.ts
+++ b/tests/http-api.test.ts
@@ -454,7 +454,7 @@ describe('http api test', () => {
                 .then(res => res.json())
                 .then(res => {
                     expect(res.error).toBeDefined();
-                    expect(res.code).toBe(400);
+                    expect(res.code).toBe(413);
                     done();
                 })
                 .catch(error => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,6 @@
 import async from 'async';
 import { Log } from '../src/log';
+import { PusherApiMessage } from '../src/message';
 import { Server } from './../src/server';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -213,6 +214,10 @@ export class Utils {
 
     static sendEventToChannel(pusher, channel: string|string[], event: string, body: any): any {
         return pusher.trigger(channel, event, body);
+    }
+
+    static sendBatches(pusher, events: PusherApiMessage[]): any {
+        return pusher.triggerBatch(events);
     }
 
     static signTokenForPrivateChannel(

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -216,7 +216,7 @@ export class Utils {
         return pusher.trigger(channel, event, body);
     }
 
-    static sendBatches(pusher, events: PusherApiMessage[]): any {
+    static sendBatch(pusher, events: PusherApiMessage[]): any {
         return pusher.triggerBatch(events);
     }
 


### PR DESCRIPTION
Closes #238

As explained here: https://pusher.com/docs/channels/library_auth_reference/rest-api/#post-batch-events-trigger-multiple-events

- Moved PresenceMember class to the presence channel manager
- Added type hints for messages
- On `/events` and `/batch_events`, when the message payload is too big, it throws 413 instead of `400`
- Added `/batch_events` call and a variable `EVENT_MAX_BATCH_SIZE=10` to define the maximum amount of messages per batch

Caveats:

- `?info=` is not supported (yet). Filtering options will be added in a later version (alongside with [`/channels`'s filtering](https://pusher.com/docs/channels/library_auth_reference/rest-api/#get-channels-fetch-info-for-multiple-channels))