### PR TITLE
[fix] Do not close the connection on empty POST payload

### DIFF
--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -417,19 +417,22 @@ export class HttpHandler {
             let chunk = Buffer.from(ab);
 
             if (isLast) {
-                let json;
-                let raw;
+                let json = {};
+                let raw = '{}';
 
                 if (buffer) {
                     try {
                         // @ts-ignore
                         json = JSON.parse(Buffer.concat([buffer, chunk]));
                     } catch (e) {
-                        res.close();
-                        return;
+                        //
                     }
 
-                    raw = Buffer.concat([buffer, chunk]).toString();
+                    try {
+                        raw = Buffer.concat([buffer, chunk]).toString();
+                    } catch (e) {
+                        //
+                    }
 
                     cb(json, raw);
                     loggingAction(json);
@@ -439,8 +442,7 @@ export class HttpHandler {
                         json = JSON.parse(chunk);
                         raw = chunk.toString();
                     } catch (e) {
-                        res.close();
-                        return;
+                        //
                     }
 
                     cb(json, raw);


### PR DESCRIPTION
Sending empty POST requests would crash the server:

```
C:\Users\renno\Desktop\package-tester\packages\uws\dist\http-handler.js:365    
        return res.writeStatus(status)
                   ^

Error: Invalid access of discarded (invalid, deleted) uWS.HttpResponse/SSLHttpResponse.
    at HttpHandler.sendJson (C:\Users\renno\Desktop\package-tester\packages\uws\dist\http-handler.js:365:20)
    at HttpHandler.badResponse (C:\Users\renno\Desktop\package-tester\packages\uws\dist\http-handler.js:210:21)
    at C:\Users\renno\Desktop\package-tester\packages\uws\dist\http-handler.js:237:25
    at C:\Users\renno\Desktop\package-tester\packages\uws\dist\http-handler.js:341:29
```