### PR TITLE
[fix] Presence members' types

### DIFF
--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -1,5 +1,5 @@
 import { Namespace } from '../namespace';
-import { PresenceMember } from '../channels/presence-channel-manager';
+import { PresenceMemberInfo } from '../channels/presence-channel-manager';
 import { WebSocket } from 'uWebSockets.js';
 
 const Discover = require('node-discover');
@@ -63,7 +63,7 @@ export interface AdapterInterface {
     /**
      * Get a given presence channel's members.
      */
-    getChannelMembers(appId: string, channel: string, onlyLocal?: boolean): Promise<Map<string, PresenceMember>>;
+    getChannelMembers(appId: string, channel: string, onlyLocal?: boolean): Promise<Map<string, PresenceMemberInfo>>;
 
     /**
      * Get a given presence channel's members count

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -3,7 +3,7 @@ import { ClusterAdapter } from './cluster-adapter';
 import { LocalAdapter } from './local-adapter';
 import { Log } from '../log';
 import { Namespace } from '../namespace';
-import { PresenceMember } from '../channels/presence-channel-manager';
+import { PresenceMemberInfo } from '../channels/presence-channel-manager';
 import { RedisAdapter } from './redis-adapter';
 import { Server } from '../server';
 import { WebSocket } from 'uWebSockets.js';
@@ -81,7 +81,7 @@ export class Adapter implements AdapterInterface {
     /**
      * Get a given presence channel's members.
      */
-    async getChannelMembers(appId: string, channel: string, onlyLocal = false): Promise<Map<string, PresenceMember>> {
+    async getChannelMembers(appId: string, channel: string, onlyLocal = false): Promise<Map<string, PresenceMemberInfo>> {
         return this.driver.getChannelMembers(appId, channel, onlyLocal);
     }
 

--- a/src/adapters/horizontal-adapter.ts
+++ b/src/adapters/horizontal-adapter.ts
@@ -1,6 +1,6 @@
 import { LocalAdapter } from './local-adapter';
 import { Log } from '../log';
-import { PresenceMember } from '../channels/presence-channel-manager';
+import { PresenceMemberInfo } from '../channels/presence-channel-manager';
 import { v4 as uuidv4 } from 'uuid';
 import { WebSocket } from 'uWebSockets.js';
 
@@ -27,7 +27,7 @@ export interface RequestExtra {
     numSub?: number;
     msgCount?: number;
     sockets?: Map<string, any>;
-    members?: Map<string, PresenceMember>;
+    members?: Map<string, PresenceMemberInfo>;
     channels?: Map<string, Set<string>>;
     totalCount?: number;
 }
@@ -53,7 +53,7 @@ export interface RequestBody extends RequestOptions {
 export interface Response {
     requestId: string;
     sockets?: Map<string, WebSocket>;
-    members?: [string, PresenceMember][];
+    members?: [string, PresenceMemberInfo][];
     channels?: [string, string[]][];
     totalCount?: number;
     exists?: boolean;
@@ -284,7 +284,7 @@ export abstract class HorizontalAdapter extends LocalAdapter {
     /**
      * Get all the channel sockets associated with a namespace.
      */
-    async getChannelMembers(appId: string, channel: string, onlyLocal = false): Promise<Map<string, PresenceMember>> {
+    async getChannelMembers(appId: string, channel: string, onlyLocal = false): Promise<Map<string, PresenceMemberInfo>> {
         return new Promise((resolve, reject) => {
             super.getChannelMembers(appId, channel).then(localMembers => {
                 if (onlyLocal) {

--- a/src/adapters/local-adapter.ts
+++ b/src/adapters/local-adapter.ts
@@ -1,6 +1,6 @@
 import { AdapterInterface } from './adapter-interface';
 import { Namespace } from '../namespace';
-import { PresenceMember } from '../channels/presence-channel-manager';
+import { PresenceMemberInfo } from '../channels/presence-channel-manager';
 import { Server } from '../server';
 import { WebSocket } from 'uWebSockets.js';
 
@@ -80,7 +80,7 @@ export class LocalAdapter implements AdapterInterface {
     /**
      * Get a given presence channel's members.
      */
-    async getChannelMembers(appId: string, channel: string, onlyLocal = false): Promise<Map<string, PresenceMember>> {
+    async getChannelMembers(appId: string, channel: string, onlyLocal = false): Promise<Map<string, PresenceMemberInfo>> {
         return this.getNamespace(appId).getChannelMembers(channel);
     }
 

--- a/src/channels/presence-channel-manager.ts
+++ b/src/channels/presence-channel-manager.ts
@@ -5,9 +5,13 @@ import { PusherMessage } from '../message';
 import { Utils } from '../utils';
 import { WebSocket } from 'uWebSockets.js';
 
+export interface PresenceMemberInfo {
+    [key: string]: any;
+}
+
 export interface PresenceMember {
     user_id: number|string;
-    user_info: any;
+    user_info: PresenceMemberInfo;
     socket_id?: string;
 }
 

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -201,7 +201,7 @@ export class HttpHandler {
 
             this.server.adapter.getChannelMembers(res.params.appId, res.params.channel).then(members => {
                 let broadcastMessage = {
-                    users: [...members].map(([user_id, user_info]) => ({ id: user_id })),
+                    users: [...members].map(([user_id, ]) => ({ id: user_id })),
                 };
 
                 this.server.metricsManager.markApiMessage(res.params.appId, {}, broadcastMessage);

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,4 +1,4 @@
-import { PresenceMember } from './channels/presence-channel-manager';
+import { PresenceMember, PresenceMemberInfo } from './channels/presence-channel-manager';
 import { WebSocket } from 'uWebSockets.js';
 
 export class Namespace {
@@ -127,17 +127,17 @@ export class Namespace {
     /**
      * Get a given presence channel's members.
      */
-    getChannelMembers(channel: string): Promise<Map<string, PresenceMember>> {
+    getChannelMembers(channel: string): Promise<Map<string, PresenceMemberInfo>> {
         return this.getChannelSockets(channel).then(sockets => {
             return Array.from(sockets).reduce((members, [wsId, ws]) => {
                 let member: PresenceMember = ws.presence.get(channel);
 
                 if (member) {
-                    members.set(member.user_id as string, member.user_info)
+                    members.set(member.user_id as string, member.user_info);
                 }
 
                 return members;
-            }, new Map<string, PresenceMember>());
+            }, new Map<string, PresenceMemberInfo>());
         });
     }
 }


### PR DESCRIPTION
There was a missing type on the `PresenceMember`'s `user_info` that @stayallive pointed out.

Given this `PresenceMember`:

```typescript
export interface PresenceMemberInfo {
    [key: string]: any;
}

export interface PresenceMember {
    user_id: number|string;
    user_info: PresenceMemberInfo;
    socket_id?: string;
}
```

It seems like the entire time, adapters would return maps with `user_id` as key and `user_info` as value as opposed to their "Promise" to return `PresenceMember`. After this fix, the hints would look ok as described below.

To clear out, when retrieving presence members with adapters there is one return type and the `ws.presence` within the WebSocket connection is another type.

- `ws.presence` stores channel names as keys and `{ user_info, user_id }` objects as values
- Adapters should return members with `user_id` as key and `user_info` as value

This does not seem to affect the way data is stored, even after an upgrade.