### PR TITLE
Pin colors to 1.4.0 as later versions have been corrupted

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "body-parser": "^1.19.1",
     "boolean": "^3.1.4",
     "bullmq": "1.64.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "dot-wild": "^3.0.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.2",


### PR DESCRIPTION
The colors package has been corrupted and causes an infinite loop when running soketi. 
Last working package version was 1.4.0 so use that.

https://nationalcybersecuritynews.today/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps-macos-macsecurity/