### PR TITLE
[fix] DynamoDB invalid default endpoint

### DIFF
--- a/src/app-managers/dynamodb-app-manager.ts
+++ b/src/app-managers/dynamodb-app-manager.ts
@@ -4,6 +4,7 @@ import { BaseAppManager } from './base-app-manager';
 import { boolean } from 'boolean';
 import { DynamoDB } from 'aws-sdk';
 import { Server } from '../server';
+import { Log } from '../log';
 
 export class DynamoDbAppManager extends BaseAppManager {
     /**
@@ -42,6 +43,11 @@ export class DynamoDbAppManager extends BaseAppManager {
 
             return new App(this.unmarshallItem(item));
         }).catch(err => {
+            if (this.server.options.debug) {
+                Log.error('Error loading app config from dynamodb');
+                Log.error(err);
+            }
+
             return null;
         });
     }
@@ -68,6 +74,11 @@ export class DynamoDbAppManager extends BaseAppManager {
 
             return new App(this.unmarshallItem(item));
         }).catch(err => {
+            if (this.server.options.debug) {
+                Log.error('Error loading app config from dynamodb');
+                Log.error(err);
+            }
+            
             return null;
         });
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -40,7 +40,7 @@ export interface Options {
         dynamodb: {
             table: string;
             region: string;
-            endpoint: string;
+            endpoint?: string;
         };
         mysql: {
             table: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,7 +53,7 @@ export class Server {
             dynamodb: {
                 table: 'apps',
                 region: 'us-east-1',
-                endpoint: '',
+                endpoint: null,
             },
             mysql: {
                 table: 'apps',


### PR DESCRIPTION
Fixes #224 

Basically, the default config option is an empty string, which the AWS client tries to connect to and fails. Errors are ignored, so after a load of debugging I realised this was the case - setting the default to null fixes the issue.

I also added logging to failed dynamodb load requests, eg if someone configured the table wrong or w/e. Seems strange this is not enabled with `debug=1` previously.

