### PR TITLE
Inform the user that their JSON config is invalid

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { Log } from '..';
 import { Server } from './../server';
 
 export class Cli {
@@ -161,7 +162,7 @@ export class Cli {
                 this.server.setOptions(settingObject);
             }
         } catch (e) {
-            //
+            Log.error('There was an error while parsing the JSON in your config file. It has not been loaded.');
         }
     }
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -162,7 +162,7 @@ export class Cli {
                 this.server.setOptions(settingObject);
             }
         } catch (e) {
-            Log.error('There was an error while parsing the JSON in your config file. It has not been loaded.');
+            Log.errorTitle('There was an error while parsing the JSON in your config file. It has not been loaded.');
         }
     }
 


### PR DESCRIPTION
Was setting up Soketi earlier, spent about 15 minutes trying to figure out why my config wasn't loading before I realised I'd missed a comma

Thought this would be helpful. Let me know what you think.

![soketi](https://user-images.githubusercontent.com/30434619/152195095-dc9d655b-b837-4093-9684-1c318a8eb59d.png)
