### PR TITLE
[feature/fix] Resolve promises in case timeout is reached looking for another nodes' responses in horizontal scaling

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Setup NATS
         if: "matrix.adapter == 'nats'"
         run: |
-          docker run -d --name nats-main \
+          docker run -d \
             -p 4222:4222 \
             -p 6222:6222 \
             -p 8222:8222 \
@@ -163,7 +163,7 @@ jobs:
       - name: Setup NATS
         if: "matrix.adapter == 'nats'"
         run: |
-          docker run -d --name nats-main \
+          docker run -d \
             -p 4222:4222 \
             -p 6222:6222 \
             -p 8222:8222 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Setup NATS
         if: "matrix.adapter == 'nats'"
         run: |
-          docker run -d --name nats-main \
+          docker run -d \
             -p 4222:4222 \
             -p 6222:6222 \
             -p 8222:8222 \

--- a/src/adapters/cluster-adapter.ts
+++ b/src/adapters/cluster-adapter.ts
@@ -17,6 +17,7 @@ export class ClusterAdapter extends HorizontalAdapter {
         this.channel = server.clusterPrefix(this.channel);
         this.requestChannel = `${this.channel}#comms#req`;
         this.responseChannel = `${this.channel}#comms#res`;
+        this.requestsTimeout = server.options.adapter.cluster.requestsTimeout;
     }
 
     /**

--- a/src/adapters/horizontal-adapter.ts
+++ b/src/adapters/horizontal-adapter.ts
@@ -71,7 +71,7 @@ export abstract class HorizontalAdapter extends LocalAdapter {
     /**
      * The time (in ms) for the request to be fulfilled.
      */
-    public requestsTimeout = 2_000;
+    public requestsTimeout = 5_000;
 
     /**
      * The channel to listen for new requests.

--- a/src/adapters/nats-adapter.ts
+++ b/src/adapters/nats-adapter.ts
@@ -39,6 +39,8 @@ export class NatsAdapter extends HorizontalAdapter {
 
         this.jc = JSONCodec();
         this.sc = StringCodec();
+
+        this.requestsTimeout = server.options.adapter.nats.requestsTimeout;
     }
 
     /**

--- a/src/adapters/redis-adapter.ts
+++ b/src/adapters/redis-adapter.ts
@@ -33,6 +33,8 @@ export class RedisAdapter extends HorizontalAdapter {
 
         this.requestChannel = `${this.channel}#comms#req`;
         this.responseChannel = `${this.channel}#comms#res`;
+
+        this.requestsTimeout = server.options.adapter.redis.requestsTimeout;
     }
 
     /**

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,14 +14,17 @@ export class Cli {
      */
     public envVariables: { [key: string]: string; } = {
         ADAPTER_DRIVER: 'adapter.driver',
+        ADAPTER_CLUSTER_REQUESTS_TIMEOUT: 'adapter.cluster.requestsTimeout',
         ADAPTER_REDIS_PREFIX: 'adapter.redis.prefix',
         ADAPTER_REDIS_CLUSTER_MODE: 'adapter.redis.clusterMode',
+        ADAPTER_REDIS_REQUESTS_TIMEOUT: 'adapter.redis.requestsTimeout',
         ADAPTER_NATS_PREFIX: 'adapter.nats.prefix',
         ADAPTER_NATS_SERVERS: 'adapter.nats.servers',
         ADAPTER_NATS_USER: 'adapter.nats.user',
         ADAPTER_NATS_PASSWORD: 'adapter.nats.pass',
         ADAPTER_NATS_TOKEN: 'adapter.nats.token',
         ADAPTER_NATS_TIMEOUT: 'adapter.nats.timeout',
+        ADAPTER_NATS_REQUESTS_TIMEOUT: 'adapter.nats.requestsTimeout',
         APP_MANAGER_DRIVER: 'appManager.driver',
         APP_MANAGER_DYNAMODB_TABLE: 'appManager.dynamodb.table',
         APP_MANAGER_DYNAMODB_REGION: 'appManager.dynamodb.region',

--- a/src/options.ts
+++ b/src/options.ts
@@ -37,18 +37,23 @@ export interface Options {
     adapter: {
         driver: string;
         redis: {
+            requestsTimeout: number;
             prefix: string;
             redisOptions: any;
             clusterMode: boolean;
         };
+        cluster: {
+            requestsTimeout: 5_000,
+        },
         nats: {
+            requestsTimeout: number;
             prefix: string;
             servers: string[];
             user?: string;
             pass?: string|null;
             token: string|null;
             timeout: number;
-        },
+        };
     };
     appManager: {
         driver: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,13 +29,18 @@ export class Server {
         adapter: {
             driver: 'local',
             redis: {
+                requestsTimeout: 5_000,
                 prefix: '',
                 redisOptions: {
                     //
                 },
                 clusterMode: false,
             },
+            cluster: {
+                requestsTimeout: 5_000,
+            },
             nats: {
+                requestsTimeout: 5_000,
                 prefix: '',
                 servers: ['127.0.0.1:4222'],
                 user: null,


### PR DESCRIPTION
Lowered timeout to 2s
Made resolvers better
Now in case timeout is reached, the promise gets resolved instantly.