### PR TITLE
[feature] Return `user_info` on the `/users` HTTP endpoint 

### DIFF
--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -237,7 +237,9 @@ export class HttpHandler {
 
             this.server.adapter.getChannelMembers(res.params.appId, res.params.channel).then(members => {
                 let broadcastMessage = {
-                    users: [...members].map(([user_id, user_info]) => ({ id: user_id, user_info })),
+                    users: [...members].map(([user_id, user_info]) => (res.query.with_user_info === '1' 
+                       ? { id: user_id, user_info } 
+                       : { id: user_id })),
                 };
 
                 this.server.metricsManager.markApiMessage(res.params.appId, {}, broadcastMessage);

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -237,7 +237,7 @@ export class HttpHandler {
 
             this.server.adapter.getChannelMembers(res.params.appId, res.params.channel).then(members => {
                 let broadcastMessage = {
-                    users: [...members].map(([user_id, ]) => ({ id: user_id })),
+                    users: [...members].map(([user_id, ...user_info]) => ({ id: user_id, user_info })),
                 };
 
                 this.server.metricsManager.markApiMessage(res.params.appId, {}, broadcastMessage);

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -237,7 +237,7 @@ export class HttpHandler {
 
             this.server.adapter.getChannelMembers(res.params.appId, res.params.channel).then(members => {
                 let broadcastMessage = {
-                    users: [...members].map(([user_id, ...user_info]) => ({ id: user_id, user_info })),
+                    users: [...members].map(([user_id, user_info]) => ({ id: user_id, user_info })),
                 };
 
                 this.server.metricsManager.markApiMessage(res.params.appId, {}, broadcastMessage);


### PR DESCRIPTION
Despite not being part of the Pushers API, this addition does not impact any implementation that makes use of this endpoint. 

It will add the user_info attribute to the object that already exists, opening up new possibilities for use.