### PR TITLE
revert uWebSockets.js package to before migration to BoringSSL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "rate-limiter-flexible": "^2.3.6",
     "sqs-consumer": "^5.6.0",
     "uuid": "^8.3.2",
-    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js.git#v20.6.0",
+    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js.git#v20.0.0",
     "yargs": "^17.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
In release v2.1.0 of uWebSockets.js they introduced an alternative cryptography package (instead of OpenSSL) which is causing issues with SSL. Reverting the package to the v20.0.0 release fixes this issue.

This PR resolves #449 