### PR TITLE
[Fix] Webhook filtering when batching is enabled

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { Log } from '..';
 import { Server } from './../server';
 
 export class Cli {
@@ -182,7 +183,7 @@ export class Cli {
                 this.server.setOptions(settingObject);
             }
         } catch (e) {
-            //
+            Log.errorTitle('There was an error while parsing the JSON in your config file. It has not been loaded.');
         }
     }
 

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -26,7 +26,6 @@ export interface JobData {
         time_ms: number;
         events: ClientEventData[];
     },
-    pusherSignature: string;
 }
 
 /**

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -26,6 +26,7 @@ export interface JobData {
         time_ms: number;
         events: ClientEventData[];
     },
+    pusherSignature: string;
 }
 
 /**

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -26,7 +26,7 @@ export interface JobData {
         time_ms: number;
         events: ClientEventData[];
     },
-    pusherSignature: string;
+    originalPusherSignature: string;
 }
 
 /**
@@ -56,10 +56,18 @@ export class WebhookSender {
         let queueProcessor = (job, done) => {
             let rawData: JobData = job.data;
 
-            const { appKey, payload } = rawData;
+            const { appKey, payload, originalPusherSignature } = rawData;
 
             server.appManager.findByKey(appKey).then(app => {
+                // Ensure the payload hasn't been tampered with between the job being dispatched
+                // and here, as we may need to recalculate the signature post filtration.
+                if (originalPusherSignature !== createWebhookHmac(JSON.stringify(payload), app.secret)) {
+                    return;
+                }
+
                 async.each(app.webhooks, (webhook: WebhookInterface, resolveWebhook) => { 
+                    const originalEventsLength = payload.events.length;
+
                     payload.events = payload.events.filter(function (event) {
                         if (!webhook.event_types.includes(event.name)) {
                             return false;
@@ -83,7 +91,8 @@ export class WebhookSender {
                         return resolveWebhook();
                     }
 
-                    let pusherSignature = createWebhookHmac(JSON.stringify(payload), app.secret);
+                    // If any events have been filtered out, regenerate the signature
+                    let pusherSignature = (originalEventsLength !== payload.events.length) ? createWebhookHmac(JSON.stringify(payload), app.secret) : originalPusherSignature;
 
                     if (this.server.options.debug) {
                         Log.webhookSenderTitle('🚀 Processing webhook from queue.');
@@ -277,10 +286,13 @@ export class WebhookSender {
             events,
         };
 
+        let originalPusherSignature = createWebhookHmac(JSON.stringify(payload), app.secret);
+
         this.server.queueManager.addToQueue(queueName, {
             appKey: app.key,
             appId: app.id,
             payload,
+            originalPusherSignature,
         });
     }
 


### PR DESCRIPTION
Runs a filter on the events array, then makes sure the events array isn't empty before generating the signature and sending the webhook