### PR TITLE
fix: Not logging non string output.

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -85,8 +85,12 @@ export class Log {
         return message;
     }
 
-    protected static log(message: string, ...styles: string[]): void {
+    protected static log(message: any, ...styles: string[]): void {
         let withColor = colors;
+
+        if (typeof message !== 'string') {
+            return console.log(message);
+        }
 
         styles
             .filter(style => ! /^[m|p]x-/.test(style))


### PR DESCRIPTION
This PR fixes #451, by detecting if the message is not a string, and output just a `console.log`.