### PR TITLE
[fix/0.x] Make sure current time is after the cache expiry before removing, on the memory cache driver

### DIFF
--- a/src/cache-managers/memory-cache-manager.ts
+++ b/src/cache-managers/memory-cache-manager.ts
@@ -26,7 +26,7 @@ export class MemoryCacheManager implements CacheManagerInterface {
             for (let [key, { ttlSeconds, setTime }] of Object.entries(this.memory)) {
                 let currentTime = parseInt((new Date().getTime() / 1000) as unknown as string);
 
-                if (ttlSeconds > 0 && (setTime + ttlSeconds) >= currentTime) {
+                if (ttlSeconds > 0 && (setTime + ttlSeconds) <= currentTime) {
                     delete this.memory[key];
                 }
             }


### PR DESCRIPTION
Makes sure we only delete cache items when they're past their TTL, rather than before