### PR TITLE
Add way to pass config to soketi-pm2 to fix #320

### DIFF
--- a/bin/pm2.js
+++ b/bin/pm2.js
@@ -4,4 +4,10 @@ const { Cli } = require('./../dist/cli/cli');
 
 process.title = 'soketi-server';
 
-Cli.startWithPm2();
+if (process.argv[3] && process.argv[3].indexOf("--config=") > -1) {
+  console.log(process.argv[3]);
+    config = {config: process.argv[3].replace("--config=", "")}
+    Cli.startWithPm2(config);
+} else {
+    Cli.startWithPm2();
+}


### PR DESCRIPTION
This is just a hack-y way to pass the config file to `soketi-pm2` to match `soketi start --config=/path/to/config.json`