### PR TITLE
[1.x] Get rid of gathering the total sockets count in Prometheus

### DIFF
--- a/src/metrics/prometheus-metrics-driver.ts
+++ b/src/metrics/prometheus-metrics-driver.ts
@@ -81,20 +81,16 @@ export class PrometheusMetricsDriver implements MetricsInterface {
      * Handle a new connection.
      */
     markNewConnection(ws: WebSocket): void {
-        this.server.adapter.getSocketsCount(ws.app.id).then(count => {
-            this.metrics.connectedSockets.set(this.getTags(ws.app.id), count);
-            this.metrics.newConnectionsTotal.inc(this.getTags(ws.app.id));
-        });
+        this.metrics.connectedSockets.inc(this.getTags(ws.app.id));
+        this.metrics.newConnectionsTotal.inc(this.getTags(ws.app.id));
     }
 
     /**
      * Handle a disconnection.
      */
     markDisconnection(ws: WebSocket): void {
-        this.server.adapter.getSocketsCount(ws.app.id).then(count => {
-            this.metrics.connectedSockets.set(this.getTags(ws.app.id), count);
-            this.metrics.newDisconnectionsTotal.inc(this.getTags(ws.app.id));
-        });
+        this.metrics.connectedSockets.dec(this.getTags(ws.app.id));
+        this.metrics.newDisconnectionsTotal.inc(this.getTags(ws.app.id));
     }
 
     /**


### PR DESCRIPTION
For some reason, the Prometheus metrics required getting the total sockets count globally. Local ones are alright, and they don't even require something else than `.inc()` and `.dec()` on the gauges.

This will ease the traffic more in case you have metrics enabled on horizontal scaling infra.