### PR TITLE
Add ws user on presence channel

### DIFF
--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -409,7 +409,8 @@ export class WsHandler {
                 let { user_id, user_info } = response.member;
 
                 ws.presence.set(channel, response.member);
-
+                ws.user = {id: user_id as string};
+                
                 // Make sure to update the socket after new data was pushed in.
                 this.server.adapter.addSocket(ws.app.id, ws);
 


### PR DESCRIPTION
If you are not authenticating in user with `client.signin();` the ws object do not have the user information. It result that you cannot terminate user connection using `/users/[user_id]/terminate_connections`  as the user_id is not linked to the connection.